### PR TITLE
feat: Add build script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "main.js",
   "scripts": {
     "start": "vite",
-    "dev": "vite"
+    "dev": "vite",
+    "build": "vite build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds the `build` script to `package.json` to enable building the project via `npm run build`. This is required for the CI pipeline to run successfully.