### PR TITLE
feat: Improve camera and speed controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,8 @@
             <div id="info-panel-resize-handle"></div>
         </div>
         <div id="controls-panel" class="panel">
-            <label for="speed-slider">Speed</label>
-            <input type="range" id="speed-slider" min="0" max="500" value="50">
+            <label for="speed-slider">Speed: <span id="speed-value">1x</span></label>
+            <input type="range" id="speed-slider" min="0" max="6" value="1" step="1">
             <button id="pause-btn" class="control-btn">Pause</button>
             <button id="reset-btn" class="control-btn">Reset</button>
         </div>
@@ -44,7 +44,7 @@
                     <!-- Items will be populated by JS -->
                 </div>
             </div>
-            <button id="free-camera-btn" class="control-btn hidden">Free Camera</button>
+            <button id="free-camera-btn" class="control-btn hidden">Solar System View</button>
         </div>
     </div>
 

--- a/js/dom.js
+++ b/js/dom.js
@@ -8,6 +8,7 @@ export const infoAdvancedDetails = document.getElementById('info-advanced-detail
 export const advancedDetailsToggle = document.getElementById('advanced-details-toggle');
 export const advancedDetailsContent = document.getElementById('advanced-details-content');
 export const speedSlider = document.getElementById('speed-slider');
+export const speedValue = document.getElementById('speed-value');
 export const pauseButton = document.getElementById('pause-btn');
 export const resetButton = document.getElementById('reset-btn');
 export const canvas = document.querySelector('#bg');

--- a/js/interactions.js
+++ b/js/interactions.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { speedLevels } from '../main.js';
 
 export function setupInteractions(camera, selectableObjects, sun, domElements, simulation, onBodySelected, controls, resetSimulation) {
     const raycaster = new THREE.Raycaster();
@@ -29,7 +30,10 @@ export function setupInteractions(camera, selectableObjects, sun, domElements, s
     });
 
     domElements.speedSlider.addEventListener('input', (event) => {
-        simulation.speed = Number(event.target.value);
+        const speedIndex = parseInt(event.target.value, 10);
+        simulation.speed = speedLevels[speedIndex];
+        domElements.speedValue.textContent = `${speedLevels[speedIndex]}x`;
+
         if (simulation.isPaused) {
             simulation.isPaused = false;
             domElements.pauseButton.textContent = 'Pause';
@@ -55,5 +59,5 @@ export function setupInteractions(camera, selectableObjects, sun, domElements, s
     });
 
     // Initial state
-    simulation.focusTarget = sun;
+    // simulation.focusTarget = sun; // Let's start with a free camera
 }

--- a/main.js
+++ b/main.js
@@ -14,17 +14,18 @@ const { scene, camera, renderer, controls, pointLight } = setupScene(DOM.canvas)
 const textureLoader = new THREE.TextureLoader();
 
 // --- State ---
+export const speedLevels = [0.5, 1, 2, 4, 8, 16, 32];
 const celestialObjects = [];
 const selectableObjects = [];
 let sun;
 const simulation = {
-    speed: 50,
+    speed: speedLevels[1],
     isPaused: false,
     selectedObject: null,
     focusTarget: null,
     time: 0,
     // Store the last speed before pausing
-    lastSpeed: 50,
+    lastSpeed: speedLevels[1],
 };
 
 // --- Object Creation ---

--- a/style.css
+++ b/style.css
@@ -198,6 +198,10 @@ canvas {
     transform: scale(0.95);
 }
 
+.control-btn.hidden {
+    display: none;
+}
+
 /* --- Selection Panel --- */
 #selection-panel {
     top: 80px; /* Adjusted position */


### PR DESCRIPTION
This commit introduces two main improvements to the solar system simulation based on user feedback.

Camera Controls:
- The simulation now starts in a 'free camera' mode, no longer defaulting to a focus on the Sun.
- The camera focus button is hidden by default.
- When a celestial body is selected, a 'Solar System View' button appears, allowing the user to click it to return to the free camera mode.

Speed Controls:
- The simulation speed slider now snaps to discrete values: 0.5x, 1x, 2x, 4x, 8x, 16x, 32x.
- The current simulation speed is displayed next to the slider for clarity.
- The simulation starts at a default speed of 1x.