### PR TITLE
feat: Enhance camera controls and add speed levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,35 @@ A 3D interactive solar system simulator built with JavaScript and Three.js. This
 
 ## Features
 
-*   **3D Solar System Visualization:** Renders the sun, planets, and major moons in a 3D space using Three.js.
-*   **Dynamic Orbital Simulation:** Planets and moons orbit their parent bodies based on real-world orbital periods. The simulation speed is adjustable.
-*   **Celestial Body Selector:** A hierarchical dropdown menu allows for easy navigation to any celestial body, including planets and their moons.
+### Core Simulation
+*   **3D Solar System Visualization:** Renders the sun, planets, and major moons in a 3D space using Three.js, with realistic textures and lighting.
+*   **Dynamic Orbital Simulation:** Planets and moons orbit their parent bodies based on real-world orbital periods.
+*   **Adjustable Simulation Speed:** The simulation speed is adjustable from 0.5x up to 128x, with a new slider design that includes markings for each speed level.
+
+### Camera and Interaction
 *   **Advanced Camera Controls:**
-    *   Smooth, animated camera transitions when selecting a new object.
-    *   Click on any celestial body in the 3D view to focus on it.
-    *   A "Free Camera" mode to detach from any focused object and explore freely.
+    *   **Focus Mode:** Click on any celestial body in the 3D view or select it from the menu to focus the camera on it.
+    *   **Rotation:** When focused on an object, you can freely rotate the camera around it to view it from any angle.
+    *   **Zoom Limits:** The camera has a maximum zoom-in based on the object's size and a maximum zoom-out that keeps the Oort cloud in view.
+    *   **Solar System View:** A "Solar System View" button allows you to detach the camera from any focused object and explore the entire system freely.
+    *   **Smooth Transitions:** The camera performs smooth, animated transitions when selecting a new object.
+*   **Celestial Body Selector:** A hierarchical dropdown menu allows for easy navigation and selection of any celestial body, including planets and their moons.
+
+### UI and Information
 *   **Interactive Information Panel:**
-    *   Displays key data (radius, distance from the sun, orbital period) for any selected celestial body.
-    *   The panel is positioned on the right side of the screen and is draggable, resizable, and closable.
+    *   Displays key data (radius, distance from the sun, orbital period, etc.) for any selected celestial body.
+    *   The panel is draggable, resizable, and closable for a customizable viewing experience.
     *   Features a dynamic colored border that matches the color of the selected celestial body.
-*   **Astronomical Scenery:** The scene includes a rich, starry background, a procedurally generated asteroid belt between Mars and Jupiter, and a representation of the Oort cloud at the edge of the system.
-*   **Detailed and Realistic Planetary Rings:** Each of the four gas giants features a unique and detailed ring system, modeled with realistic lighting and textures.
-    *   **Jupiter:** A faint, wispy, and dusty main ring with even fainter "gossamer" rings, rendered with a particle system to capture its delicate, reddish nature.
-    *   **Saturn:** Its iconic, dazzling ring system with distinct A, B, and C bands, separated by the Cassini Division. The rings are rendered with a high-resolution texture and realistic lighting to appear bright and icy.
-    *   **Uranus:** A system of narrow, dark, charcoal-gray rings, rendered with a material that gives them a subtle, rocky appearance.
-    *   **Neptune:** Dim, patchy, and bluish-tinted rings, featuring the famous bright, clumpy arcs in the outer Adams ring.
+    *   Includes tooltips to explain astronomical terms.
+
+### Astronomical Scenery
+*   **Rich Starry Background:** The scene includes a vast, starry background with 10,000 stars to create an immersive environment.
+*   **Asteroid Belt:** A procedurally generated asteroid belt is rendered between the orbits of Mars and Jupiter.
+*   **Oort Cloud:** A representation of the Oort cloud is included at the edge of the solar system, defining the boundary of the simulation.
+*   **Detailed Planetary Systems:**
+    *   **Earth's Clouds:** Earth is rendered with a dynamic, transparent cloud layer.
+    *   **Realistic Planetary Rings:** Each of the four gas giants features a unique and detailed ring system:
+        *   **Jupiter:** A faint, wispy, and dusty main ring with even fainter "gossamer" rings.
+        *   **Saturn:** Its iconic, bright, and icy ring system with distinct A, B, and C bands, separated by the Cassini Division.
+        *   **Uranus:** A system of narrow, dark, charcoal-gray rings.
+        *   **Neptune:** Dim, patchy, and bluish-tinted rings, featuring bright, clumpy arcs in the outer Adams ring.

--- a/index.html
+++ b/index.html
@@ -33,7 +33,18 @@
         </div>
         <div id="controls-panel" class="panel">
             <label for="speed-slider">Speed: <span id="speed-value">1x</span></label>
-            <input type="range" id="speed-slider" min="0" max="6" value="1" step="1">
+            <input type="range" id="speed-slider" min="0" max="8" value="1" step="1" list="speed-markers">
+            <datalist id="speed-markers">
+                <option value="0"></option>
+                <option value="1"></option>
+                <option value="2"></option>
+                <option value="3"></option>
+                <option value="4"></option>
+                <option value="5"></option>
+                <option value="6"></option>
+                <option value="7"></option>
+                <option value="8"></option>
+            </datalist>
             <button id="pause-btn" class="control-btn">Pause</button>
             <button id="reset-btn" class="control-btn">Reset</button>
         </div>

--- a/js/interactions.js
+++ b/js/interactions.js
@@ -25,7 +25,7 @@ export function setupInteractions(camera, selectableObjects, sun, domElements, s
             domElements.infoPanel.classList.add('hidden');
             domElements.freeCameraButton.classList.add('hidden');
             controls.minDistance = 0;
-            controls.maxDistance = Infinity;
+            controls.maxDistance = 1600; // Oort cloud visible
         }
     });
 
@@ -55,7 +55,15 @@ export function setupInteractions(camera, selectableObjects, sun, domElements, s
         simulation.focusTarget = null;
         domElements.freeCameraButton.classList.add('hidden');
         controls.minDistance = 0; // Reset zoom constraint
-        controls.maxDistance = Infinity;
+        controls.maxDistance = 1600; // Oort cloud visible
+    });
+
+    // --- User Interaction Tracking ---
+    controls.addEventListener('start', () => {
+        simulation.isUserInteracting = true;
+    });
+    controls.addEventListener('end', () => {
+        simulation.isUserInteracting = false;
     });
 
     // Initial state

--- a/main.js
+++ b/main.js
@@ -14,10 +14,12 @@ const { scene, camera, renderer, controls, pointLight } = setupScene(DOM.canvas)
 const textureLoader = new THREE.TextureLoader();
 
 // --- State ---
-export const speedLevels = [0.5, 1, 2, 4, 8, 16, 32];
+export const speedLevels = [0.5, 1, 2, 4, 8, 16, 32, 64, 128];
 const celestialObjects = [];
 const selectableObjects = [];
 let sun;
+const MAX_ZOOM_OUT = 1600;
+
 const simulation = {
     speed: speedLevels[1],
     isPaused: false,
@@ -26,6 +28,7 @@ const simulation = {
     time: 0,
     // Store the last speed before pausing
     lastSpeed: speedLevels[1],
+    isUserInteracting: false,
 };
 
 // --- Object Creation ---
@@ -243,7 +246,7 @@ function onBodySelected(name) {
     // --- Adjust Camera ---
     const radius = scaleBodyRadius(data.radius);
     controls.minDistance = radius * 1.5;
-    controls.maxDistance = Infinity;
+    controls.maxDistance = MAX_ZOOM_OUT;
 }
 
 createCelestialBodySelector(planetData, onBodySelected);
@@ -300,17 +303,17 @@ function animate() {
             simulation.focusTarget.getWorldPosition(cameraTarget);
         }
 
-        // Smoothly move camera to a position offset from the target.
-        // The offset is scaled by the radius of the target to ensure a good view.
-        if (simulation.focusTarget.userData.data) {
+        // When an object is focused, the camera's target should smoothly follow it.
+        // The OrbitControls will handle the camera's position (rotation, zoom) relative to this target.
+        if (!simulation.isUserInteracting && simulation.focusTarget.userData.data) {
             const radius = scaleBodyRadius(simulation.focusTarget.userData.data.radius);
             const offset = new THREE.Vector3(0, radius * 0.5, radius * 4);
             const desiredCameraPosition = cameraTarget.clone().add(offset);
             // We use lerp to create a smooth animation without external libraries.
             camera.position.lerp(desiredCameraPosition, 0.05);
         }
-
     }
+
     // We always lerp the controls target to smoothly follow the selected object
     // or to stay in place if in free camera mode.
     controls.target.lerp(cameraTarget, 0.05);

--- a/style.css
+++ b/style.css
@@ -177,6 +177,52 @@ canvas {
     font-weight: 500;
 }
 
+#speed-slider {
+    width: 200px;
+    -webkit-appearance: none;
+    appearance: none;
+    background: transparent;
+    cursor: pointer;
+}
+
+#speed-slider::-webkit-slider-runnable-track {
+    background: #2a2a3a;
+    height: 6px;
+    border-radius: 3px;
+}
+
+#speed-slider::-moz-range-track {
+    background: #2a2a3a;
+    height: 6px;
+    border-radius: 3px;
+}
+
+#speed-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    margin-top: -5px; /* Centers thumb on track */
+    background-color: #fff;
+    height: 16px;
+    width: 16px;
+    border-radius: 50%;
+    border: 2px solid #333;
+}
+
+#speed-slider::-moz-range-thumb {
+    background-color: #fff;
+    height: 12px;
+    width: 12px;
+    border-radius: 50%;
+    border: 2px solid #333;
+}
+
+#speed-markers {
+    display: flex;
+    justify-content: space-between;
+    padding: 0 10px;
+    color: #fff;
+}
+
 /* --- Simulation Control Buttons --- */
 .control-btn {
     background-color: rgba(40, 40, 50, 0.8);


### PR DESCRIPTION
This commit introduces several new features and improvements:

- Implements a maximum zoom-out distance based on the Oort cloud's visibility for both free-roam and focused camera modes.
- Enables camera rotation around a focused celestial body while maintaining the smooth camera transition when an object is first selected.
- Adds 64x and 128x to the simulation speed controls and updates the UI slider with markings for all speed levels.

The README.md has also been comprehensively updated to reflect all new and existing features of the simulation.