### PR TITLE
feat: Implement dynamic light source and shadows

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,10 @@
             </datalist>
             <button id="pause-btn" class="control-btn">Pause</button>
             <button id="reset-btn" class="control-btn">Reset</button>
+            <div class="control-group">
+                <input type="checkbox" id="shadow-toggle" checked>
+                <label for="shadow-toggle">Shadows</label>
+            </div>
         </div>
         <div id="selection-panel" class="panel">
             <div id="celestial-selector" class="dropdown">

--- a/js/moons.js
+++ b/js/moons.js
@@ -9,6 +9,8 @@ export function createMoons(p_data, planetGroup, selectableObjects) {
         const moonGeometry = new THREE.SphereGeometry(scaleBodyRadius(m_data.radius), 16, 16);
         const moonMaterial = new THREE.MeshStandardMaterial({ color: m_data.color });
         const moon = new THREE.Mesh(moonGeometry, moonMaterial);
+        moon.castShadow = true;
+        moon.receiveShadow = true;
         moon.userData = { name: m_data.name, type: 'moon', data: m_data, parent: p_data };
         m_data.mesh = moon;
         planetGroup.add(moon);

--- a/js/scene.js
+++ b/js/scene.js
@@ -15,8 +15,16 @@ export function setupScene(canvas) {
     });
     renderer.setSize(window.innerWidth, window.innerHeight);
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.shadowMap.enabled = true;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 1.0;
 
     const pointLight = new THREE.PointLight(0xffffff, 500);
+    pointLight.castShadow = true;
+    pointLight.distance = 0;
+    pointLight.decay = 1;
+    pointLight.shadow.mapSize.width = 2048;
+    pointLight.shadow.mapSize.height = 2048;
     const ambientLight = new THREE.AmbientLight(0xffffff, 0.1);
     scene.add(ambientLight);
 

--- a/main.js
+++ b/main.js
@@ -54,12 +54,16 @@ planetData.forEach(p_data => {
         planet = new THREE.Mesh(planetGeometry, planetMaterial);
         sun = planet;
         sun.add(pointLight);
+        sun.castShadow = true;
+        sun.receiveShadow = false;
     } else {
         planetMaterial = new THREE.MeshStandardMaterial({ color: p_data.color });
         if (p_data.texture) {
             planetMaterial.map = textureLoader.load(p_data.texture);
         }
         planet = new THREE.Mesh(planetGeometry, planetMaterial);
+        planet.castShadow = true;
+        planet.receiveShadow = true;
 
         if (p_data.name === 'Earth' && p_data.cloudTexture) {
             const cloudGeometry = new THREE.SphereGeometry(scaleBodyRadius(p_data.radius) * 1.01, 64, 64);
@@ -71,6 +75,7 @@ planetData.forEach(p_data => {
                 opacity: 0.8,
             });
             const cloudMesh = new THREE.Mesh(cloudGeometry, cloudMaterial);
+            cloudMesh.castShadow = true;
             planet.add(cloudMesh); // Add clouds as a child of the planet
         }
     }
@@ -266,6 +271,17 @@ function resetSimulation() {
 }
 
 setupInteractions(camera, selectableObjects, sun, DOM, simulation, onBodySelected, controls, resetSimulation);
+
+// --- Shadow Toggle ---
+const shadowToggle = document.getElementById('shadow-toggle');
+shadowToggle.addEventListener('change', (e) => {
+    renderer.shadowMap.enabled = e.target.checked;
+    scene.traverse((object) => {
+        if (object.material) {
+            object.material.needsUpdate = true;
+        }
+    });
+});
 
 // --- Animation Loop ---
 const clock = new THREE.Clock();

--- a/style.css
+++ b/style.css
@@ -173,6 +173,12 @@ canvas {
     gap: 10px;
 }
 
+.control-group {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
 #controls-panel label {
     font-weight: 500;
 }


### PR DESCRIPTION
This commit introduces a dynamic light source to the solar system simulation, using the Sun as a `THREE.PointLight` that casts shadows.

Key changes:
- Enabled shadow mapping on the `WebGLRenderer`.
- Configured the `PointLight` to cast shadows, with adjusted `distance` and `decay` properties to ensure all planets are appropriately illuminated.
- Implemented tone mapping to enhance the visual quality and balance the lighting of the scene.
- Set `castShadow` and `receiveShadow` properties on all celestial bodies (planets and moons) to make them interact with the light source realistically.
- Added a UI checkbox to allow users to toggle shadows on and off for performance considerations.
- The shadow toggle event listener now correctly updates the materials in the scene to ensure the visual change is applied immediately.