### PR TITLE
Fix build error by exporting MAX_ZOOM_OUT

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,7 +18,7 @@ export const speedLevels = [0.5, 1, 2, 4, 8, 16, 32, 64, 128];
 const celestialObjects = [];
 const selectableObjects = [];
 let sun;
-const MAX_ZOOM_OUT = 1700;
+export const MAX_ZOOM_OUT = 1700;
 
 const simulation = {
     speed: speedLevels[1],


### PR DESCRIPTION
The build was failing because `js/interactions.js` was trying to import `MAX_ZOOM_OUT` from `main.js`, but it was not being exported. This commit adds the `export` keyword to the `MAX_ZOOM_OUT` constant in `main.js` to resolve the issue.