### PR TITLE
Fix Vite build process to resolve 404 errors on GitHub Pages.

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,14 +65,6 @@
         </div>
     </div>
 
-    <script type="importmap">
-    {
-        "imports": {
-            "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js",
-            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/"
-        }
-    }
-    </script>
     <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import * as THREE from './node_modules/three/build/three.module.js';
+import * as THREE from 'three';
 import * as DOM from './js/dom.js';
 import { setupScene } from './js/scene.js';
 import { planetData } from './js/data.js';
@@ -8,9 +8,7 @@ import { createMoons } from './js/moons.js';
 import { createCelestialBodySelector } from './js/dom.js';
 import { setupInteractions } from './js/interactions.js';
 import { initInfoPanel, updateInfoPanelColor } from './js/info-panel.js';
-feature/smooth-camera-transitions
-import * as TWEEN from './node_modules/@tweenjs/tween.js/dist/tween.esm.js';
-main
+import * as TWEEN from '@tweenjs/tween.js';
 
 // --- Setup ---
 const { scene, camera, renderer, controls, pointLight } = setupScene(DOM.canvas);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  base: '/solarsystemsim25/',
   server: {
     port: 3000, // Optional: specify a port
   },


### PR DESCRIPTION
The deployed website was failing to load `three.js` and `tween.js` because it was attempting to serve files directly from `node_modules`.

This commit fixes the issue by:
- Resolving a merge conflict in `main.js`.
- Configuring the project to use the intended Vite build process correctly.
- Updating `main.js` to use bare module imports for dependencies.
- Removing the unnecessary `importmap` from `index.html`.
- Adding the `base` URL to `vite.config.js` to ensure correct asset paths for the GitHub Pages deployment.

With these changes, running `npm run build` now generates a `dist` directory that is correctly configured to be deployed to GitHub Pages.