### PR TITLE
fix(textures): Correct Earth texture and cloud map URLs

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -2,7 +2,7 @@ export const planetData = [
     { name: 'Sun', radius: 696340, color: 0xffff00, semiMajorAxis: 0, orbitalPeriod: 1 },
     { name: 'Mercury', radius: 2440, color: 0x888888, semiMajorAxis: 0.387, orbitalPeriod: 88.0, texture: 'https://raw.githubusercontent.com/therealsahil19/solarsystemsim25/main/assets/8k_mercury.jpg' },
     { name: 'Venus', radius: 6052, color: 0xeeeeaa, semiMajorAxis: 0.723, orbitalPeriod: 224.7, texture: 'https://raw.githubusercontent.com/therealsahil19/solarsystemsim25/main/assets/4k_venus_atmosphere.jpg' },
-    { name: 'Earth', radius: 6371, semiMajorAxis: 1.0, orbitalPeriod: 365.2, texture: 'assets/earth.jpeg', cloudTexture: 'https://raw.githubusercontent.com/therealsahil19/solarsystemsim25/main/assets/8k_earth_clouds.jpg', moons: [
+    { name: 'Earth', radius: 6371, semiMajorAxis: 1.0, orbitalPeriod: 365.2, texture: 'https://raw.githubusercontent.com/therealsahil19/solarsystemsim25/main/assets/earth.jpeg', cloudTexture: 'http://shadedrelief.com/natural3/ne3_data/8192/clouds/fair_clouds_8k.jpg', moons: [
         { name: 'Moon', radius: 1737, color: 0xcccccc, semiMajorAxis: 0.015, orbitalPeriod: 27.3, semiMajorAxisKm: 384400 }
     ]},
     { name: 'Mars', radius: 3390, color: 0xff0000, semiMajorAxis: 1.524, orbitalPeriod: 687.0, texture: 'https://raw.githubusercontent.com/therealsahil19/solarsystemsim25/main/assets/8k_mars.jpg' },


### PR DESCRIPTION
- Replaced the relative path for the Earth texture with its absolute raw GitHub URL to ensure it is correctly loaded by the build process. This is consistent with how other planetary textures are loaded in the project.
- The original URL for the Earth's cloud map was resulting in a 404 error as the file is missing from the repository. Replaced the broken URL with a working link to a public cloud map from shadedrelief.com to restore the cloud layer.