### PR TITLE
Fix: Resolve "react" import error from "zustand"

### DIFF
--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import * as TWEEN from '@tweenjs/tween.js';
 import * as dom from './ui/dom';
-import { useStore } from './state/store';
+import { store } from './state/store';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 type Simulation = {
@@ -67,7 +67,7 @@ export function setupInteractions(
     });
 
     function updateTimeScaleUI() {
-        const speed = useStore.getState().timeScale;
+        const speed = store.getState().timeScale;
         dom.timeScaleValue.textContent = `${speed.toFixed(speed < 10 ? 1 : 0)}x`;
         dom.timeScaleInput.value = speed.toFixed(speed < 10 ? 2 : 0);
 
@@ -80,8 +80,8 @@ export function setupInteractions(
     if (dom.timeScaleSlider) {
         dom.timeScaleSlider.addEventListener('input', (event) => {
             const exponent = parseFloat((event.target as HTMLInputElement).value);
-            useStore.getState().setTimeScale(Math.pow(10, exponent));
-            useStore.getState().setPaused(false);
+            store.getState().setTimeScale(Math.pow(10, exponent));
+            store.getState().setPaused(false);
             updateTimeScaleUI();
         });
     }
@@ -90,8 +90,8 @@ export function setupInteractions(
         dom.timePresetButtons.forEach(button => {
             button.addEventListener('click', () => {
                 const speed = parseFloat(button.dataset.speed!);
-                useStore.getState().setTimeScale(speed);
-                useStore.getState().setPaused(false);
+                store.getState().setTimeScale(speed);
+                store.getState().setPaused(false);
                 updateTimeScaleUI();
             });
         });
@@ -101,15 +101,15 @@ export function setupInteractions(
         dom.timeScaleInput.addEventListener('change', (event) => {
             const speed = parseFloat((event.target as HTMLInputElement).value);
             if (!isNaN(speed) && speed > 0) {
-                useStore.getState().setTimeScale(speed);
-                useStore.getState().setPaused(false);
+                store.getState().setTimeScale(speed);
+                store.getState().setPaused(false);
             }
             updateTimeScaleUI();
         });
     }
 
     function getStepDelta() {
-        const speed = useStore.getState().timeScale;
+        const speed = store.getState().timeScale;
         if (speed >= 1000) return 30;
         if (speed >= 100) return 10;
         if (speed >= 10) return 1;
@@ -139,7 +139,7 @@ export function setupInteractions(
     updateTimeScaleUI();
 
     dom.pauseButton.addEventListener('click', () => {
-        useStore.getState().setPaused(!useStore.getState().isPaused);
+        store.getState().setPaused(!store.getState().isPaused);
     });
 
     dom.resetButton.addEventListener('click', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import { createCelestialBodySelector } from './ui/celestial-selector';
 import { setupInteractions } from './interactions';
 import { initInfoPanel, updateInfoPanelColor } from './ui/info-panel';
 import { OrbitManager } from './orbits/OrbitManager';
-import { useStore } from './state/store';
+import { store } from './state/store';
 import { setupKeyboardShortcuts } from './keyboard';
 import * as dom from './ui/dom';
 import { instantaneousOrbitalSpeed } from './orbits/kepler';
@@ -269,7 +269,7 @@ function onBodySelected(name: string) {
     const selectedObject = selectableObjects.find(obj => obj.userData.name === name);
     if (!selectedObject) return;
 
-    useStore.getState().setSelectedBodyId(name);
+    store.getState().setSelectedBodyId(name);
     simulation.focusTarget = selectedObject;
     frameObject(selectedObject);
 
@@ -367,10 +367,10 @@ initInfoPanel();
 function resetSimulation() {
     simulation.time = 0;
     simulation.focusTarget = sun!;
-    useStore.getState().setSelectedBodyId('Sun');
+    store.getState().setSelectedBodyId('Sun');
     camera.position.set(0, 150, 400);
     controls.target.set(0, 0, 0);
-    useStore.getState().setPaused(false);
+    store.getState().setPaused(false);
     onBodySelected('Sun');
     dom.smallInfoCard.classList.add('hidden');
 }
@@ -414,20 +414,20 @@ function updateDebugHUD(avg: number) {
 }
 
 function updatePauseButtonUI() {
-    dom.pauseButton.textContent = useStore.getState().isPaused ? 'Resume' : 'Pause';
+    dom.pauseButton.textContent = store.getState().isPaused ? 'Resume' : 'Pause';
 }
 
 let visibilityPaused = false;
 document.addEventListener('visibilitychange', () => {
     if (document.hidden) {
-        if (!useStore.getState().isPaused) {
+        if (!store.getState().isPaused) {
             visibilityPaused = true;
-            useStore.getState().setPaused(true);
+            store.getState().setPaused(true);
             updatePauseButtonUI();
         }
     } else {
         if (visibilityPaused) {
-            useStore.getState().setPaused(false);
+            store.getState().setPaused(false);
             visibilityPaused = false;
             updatePauseButtonUI();
         }
@@ -435,22 +435,22 @@ document.addEventListener('visibilitychange', () => {
 });
 
 window.addEventListener('blur', () => {
-    if (!useStore.getState().isPaused) {
+    if (!store.getState().isPaused) {
         visibilityPaused = true;
-        useStore.getState().setPaused(true);
+        store.getState().setPaused(true);
         updatePauseButtonUI();
     }
 });
 
 window.addEventListener('focus', () => {
     if (visibilityPaused) {
-        useStore.getState().setPaused(false);
+        store.getState().setPaused(false);
         visibilityPaused = false;
         updatePauseButtonUI();
     }
 });
 
-useStore.subscribe((state) => {
+store.subscribe((state) => {
     const selectedBody = celestialObjects.find(c => c.name === state.selectedBodyId);
     if (selectedBody) {
         simulation.focusTarget = selectedBody.mesh;
@@ -489,10 +489,10 @@ const animate: Animate = (time) => {
         updateDebugHUD(avg);
     }
 
-    if (!useStore.getState().isPaused) {
-        simulation.time += (dt / 1000) * useStore.getState().timeScale;
+    if (!store.getState().isPaused) {
+        simulation.time += (dt / 1000) * store.getState().timeScale;
         if (simulation.singleStep) {
-            useStore.getState().setPaused(true);
+            store.getState().setPaused(true);
             simulation.singleStep = false;
             updatePauseButtonUI();
         }
@@ -542,8 +542,8 @@ const animate: Animate = (time) => {
         controls.target.lerp(targetPosition, simulation.followSmoothing);
     }
 
-    if (useStore.getState().selectedBodyId) {
-        const selectedBody = celestialObjects.find(c => c.name === useStore.getState().selectedBodyId);
+    if (store.getState().selectedBodyId) {
+        const selectedBody = celestialObjects.find(c => c.name === store.getState().selectedBodyId);
         if (selectedBody && selectedBody.name !== 'Sun') {
             const planetAngle = (2 * Math.PI * simulation.time) / selectedBody.orbitalPeriod;
             const a_au = selectedBody.semiMajorAxis;

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand';
+import { createStore } from 'zustand/vanilla';
 
 interface AppState {
   selectedBodyId: string | null;
@@ -13,7 +13,7 @@ interface AppState {
   setFollowingId: (id: string | null) => void;
 }
 
-export const useStore = create<AppState>((set) => ({
+export const store = createStore<AppState>((set) => ({
   selectedBodyId: null,
   setSelectedBodyId: (id) => set({ selectedBodyId: id }),
   isPaused: false,


### PR DESCRIPTION
The application was failing with the error "Uncaught Error: Could not resolve "react" imported by "zustand"". This was because the main `zustand` package has a peer dependency on `react`, which was not included in the project.

This change resolves the issue by switching to the vanilla JavaScript version of `zustand`, which does not have a dependency on React.

The following changes were made:
- Modified `src/state/store.ts` to import `createStore` from `zustand/vanilla` instead of `create` from `zustand`.
- Renamed the exported store from `useStore` to `store` to follow conventions for non-React stores.
- Updated all usages of the store in `src/interactions.ts` and `src/main.ts` to use the new `store` object.