### PR TITLE
Fix Playwright CI timeout by correcting port and URL

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,6 +17,8 @@ jobs:
       run: npm ci
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
+    - name: Wait for dev server
+      run: npx wait-on http://localhost:3000 --timeout 60000 || (curl -v http://localhost:3000 && exit 1)
     - name: Run Playwright tests
       run: npx playwright test
     - uses: actions/upload-artifact@v4

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:3000/solarsystemsim25/',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -73,7 +73,8 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'npm run dev',
-    url: 'http://localhost:5173',
+    url: 'http://localhost:3000/solarsystemsim25/',
+    timeout: 120000,
     reuseExistingServer: !process.env.CI,
   },
 });


### PR DESCRIPTION
This commit fixes the Playwright CI timeout issue by:
1. Aligning the Playwright `webServer` port with the Vite config (3000).
2. Updating the `webServer` URL and `baseURL` to include the `/solarsystemsim25/` base path, which was found to be necessary during debugging.
3. Increasing the `webServer` timeout to 120 seconds for better stability in CI.
4. Adding a `wait-on` step to the CI workflow for improved diagnostics.

Although the tests continued to fail in the local sandbox environment, the user has instructed to push the code with these fixes.