### PR TITLE
Fix(test): Configure Vite and Playwright for base path

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint 'src/**/*.{ts,tsx,js}' --fix",
     "test": "vitest",
-    "test:watch": "vitest --watch"
+    "test:watch": "vitest --watch",
+    "test:e2e": "vite build && vite preview --port 3000"
   },
   "repository": {
     "type": "git",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -72,9 +72,9 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: 'npm run test:e2e',
     url: 'http://localhost:3000/solarsystemsim25/',
-    timeout: 120000,
+    timeout: 300000,
     reuseExistingServer: !process.env.CI,
   },
 });


### PR DESCRIPTION
The Playwright tests were failing in CI because the Vite dev server was not serving the application from the expected `/solarsystemsim25/` base path. This caused Playwright's `webServer` to time out waiting for a URL that would never become available.

This commit addresses the issue by:
1.  Adding a new `test:e2e` script to `package.json` that runs `vite build` followed by `vite preview`. This ensures the application is built respecting the `base` path from `vite.config.ts` and then served correctly.
2.  Updating `playwright.config.ts` to use the new `npm run test:e2e` command for the `webServer`. This aligns the test environment with the production build, ensuring consistency.

The `vite.config.ts` file already contained the necessary `base: '/solarsystemsim25/'` configuration.