### PR TITLE
feat(ui): Enhance Celestial Selector UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,14 +140,11 @@
                                     <label style="cursor: pointer;"><input type="radio" name="selector-view" value="type"> By Type</label>
                                 </div>
                             </div>
-                            <div class="search-container" style="display: flex; gap: 5px; margin-bottom: 5px;">
-                                <input type="text" id="selector-search-input" class="control-btn" placeholder="Search..." style="flex-grow: 1; box-sizing: border-box;">
-                                <select id="selector-type-filter" class="control-btn" title="Filter by type">
-                                    <option value="all">All Types</option>
-                                    <option value="star">Star</option>
-                                    <option value="planet">Planet</option>
-                                    <option value="moon">Moon</option>
-                                </select>
+                            <div class="search-container" style="margin-bottom: 10px;">
+                                <input type="text" id="selector-search-input" class="control-btn" placeholder="Search by name..." style="width: 100%; box-sizing: border-box;">
+                            </div>
+                            <div id="category-tabs" style="display: flex; margin-bottom: 10px; border-bottom: 1px solid rgba(255, 255, 255, 0.1);">
+                                <!-- Tabs will be dynamically inserted here -->
                             </div>
                             <div id="celestial-selector-menu" class="dropdown-menu">
                                 <!-- Tree view will be populated by JS -->

--- a/src/ui/celestial-selector.ts
+++ b/src/ui/celestial-selector.ts
@@ -13,6 +13,35 @@ let fuse: Fuse<FuseDataItem>;
 let activeNodeId: string | null = null;
 let currentView: ViewMode = 'hierarchy';
 let onSelectCallback: (id: string) => void;
+let currentFilterType: CelestialBodyType | 'all' = 'all';
+const favoritedIds = new Set<string>();
+
+function createFavoriteButton(node: TreeNode): HTMLButtonElement {
+    const favoriteBtn = document.createElement('button');
+    favoriteBtn.className = 'favorite-btn';
+    favoriteBtn.innerHTML = '&#9733;'; // Unicode star
+    if (favoritedIds.has(node.id)) {
+        favoriteBtn.classList.add('favorited');
+    }
+    favoriteBtn.addEventListener('click', (e) => {
+        e.stopPropagation(); // Prevent the row from being selected
+        if (favoritedIds.has(node.id)) {
+            favoritedIds.delete(node.id);
+            favoriteBtn.classList.remove('favorited');
+        } else {
+            favoritedIds.add(node.id);
+            favoriteBtn.classList.add('favorited');
+        }
+    });
+    return favoriteBtn;
+}
+
+function createTypeSpan(node: TreeNode): HTMLSpanElement {
+    const typeSpan = document.createElement('span');
+    typeSpan.className = 'node-type';
+    typeSpan.textContent = node.type.charAt(0).toUpperCase() + node.type.slice(1);
+    return typeSpan;
+}
 
 function renderListItem(node: TreeNode): HTMLLIElement {
     const li = document.createElement('li');
@@ -47,10 +76,14 @@ function renderListItem(node: TreeNode): HTMLLIElement {
     name.textContent = node.name;
     content.appendChild(name);
 
+    content.appendChild(createTypeSpan(node));
+
     const stats = document.createElement('span');
     stats.className = 'node-stats';
     stats.textContent = `${node.spec.radius.toLocaleString()} km`;
     content.appendChild(stats);
+
+    content.appendChild(createFavoriteButton(node));
 
     li.appendChild(content);
     node.element = li;
@@ -95,10 +128,14 @@ function renderNode(node: TreeNode): HTMLLIElement {
     name.textContent = node.name;
     content.appendChild(name);
 
+    content.appendChild(createTypeSpan(node));
+
     const stats = document.createElement('span');
     stats.className = 'node-stats';
     stats.textContent = `${node.spec.radius.toLocaleString()} km`;
     content.appendChild(stats);
+
+    content.appendChild(createFavoriteButton(node));
 
     li.appendChild(content);
 
@@ -197,9 +234,8 @@ function updateDomVisibility() {
 
 function filterTree() {
     const searchInput = document.getElementById('selector-search-input') as HTMLInputElement;
-    const typeFilter = document.getElementById('selector-type-filter') as HTMLSelectElement;
     const query = searchInput.value;
-    const selectedType = typeFilter.value;
+    const selectedType = currentFilterType;
 
     if (!query && selectedType === 'all') {
         allNodes.forEach(node => {
@@ -290,6 +326,16 @@ function setActiveNode(nodeId: string | null) {
     }
 }
 
+function debounce(func: (...args: any[]) => void, delay: number) {
+    let timeoutId: number;
+    return (...args: any[]) => {
+        clearTimeout(timeoutId);
+        timeoutId = window.setTimeout(() => {
+            func(...args);
+        }, delay);
+    };
+}
+
 export function createCelestialBodySelector(bodies: CelestialBody[], onSelect: (id:string) => void): void {
     const modal = document.getElementById('celestial-selector-modal')!;
     const openBtn = document.getElementById('open-celestial-selector-btn')!;
@@ -355,10 +401,32 @@ export function createCelestialBodySelector(bodies: CelestialBody[], onSelect: (
     });
 
     const searchInput = document.getElementById('selector-search-input') as HTMLInputElement;
-    searchInput.addEventListener('input', () => filterTree());
+    searchInput.addEventListener('input', debounce(() => filterTree(), 300));
 
-    const typeFilter = document.getElementById('selector-type-filter') as HTMLSelectElement;
-    typeFilter.addEventListener('change', () => filterTree());
+    const categoryTabsContainer = document.getElementById('category-tabs')!;
+    const categories: (CelestialBodyType | 'all')[] = ['all', 'star', 'planet', 'moon'];
+
+    categories.forEach(category => {
+        const tab = document.createElement('button');
+        tab.className = 'category-tab';
+        tab.dataset.category = category;
+
+        let text = category.charAt(0).toUpperCase() + category.slice(1);
+        if (category !== 'all') text += 's';
+        tab.textContent = text;
+
+        if (category === currentFilterType) {
+            tab.classList.add('active');
+        }
+
+        tab.addEventListener('click', () => {
+            currentFilterType = category;
+            categoryTabsContainer.querySelectorAll('.category-tab').forEach(t => t.classList.remove('active'));
+            tab.classList.add('active');
+            filterTree();
+        });
+        categoryTabsContainer.appendChild(tab);
+    });
 
     const viewRadios = document.querySelectorAll<HTMLInputElement>('input[name="selector-view"]');
     viewRadios.forEach(radio => {

--- a/style.css
+++ b/style.css
@@ -411,8 +411,13 @@ canvas {
     flex-shrink: 0;
     fill: currentColor;
 }
+.tree-node-content {
+    border-left: 3px solid transparent; /* Add transparent border for smooth transition */
+    transition: background 0.18s, border-color 0.18s;
+}
 .tree-node-content:hover, .tree-node.focused > .tree-node-content {
-    background-color: rgba(255, 255, 255, 0.1);
+    background: rgba(110, 132, 255, 0.13);
+    border-left: 3px solid #6C5CD7;
 }
 .tree-node .chevron {
     width: 20px;
@@ -425,7 +430,6 @@ canvas {
     font-weight: 500; /* Medium weight for readability */
 }
 .tree-node .node-stats {
-    margin-left: auto;
     font-size: 0.85em;
     color: #999;
     padding-right: 5px;
@@ -608,4 +612,72 @@ canvas {
 
 #new-preset-name {
     flex-grow: 1;
+}
+
+/* --- Celestial Selector UI Improvements --- */
+
+/* Category Tabs */
+#category-tabs {
+    gap: 8px; /* Spacing between tabs */
+}
+
+.category-tab {
+    background: none;
+    border: none;
+    color: #aab;
+    padding: 8px 12px;
+    cursor: pointer;
+    font-size: 1em;
+    font-weight: 500;
+    border-bottom: 3px solid transparent;
+    transition: color 0.2s, border-color 0.2s;
+}
+
+.category-tab:hover {
+    color: #fff;
+}
+
+.category-tab.active {
+    color: #fff;
+    font-weight: 600;
+    border-bottom-color: #6C5CD7;
+}
+
+/* List Item Content Layout */
+.tree-node-content .node-name {
+    flex-grow: 0; /* Don't grow to push stats away */
+}
+
+.tree-node-content .node-type {
+    font-size: 0.8em;
+    color: #888;
+    margin-left: 8px;
+    background-color: rgba(255, 255, 255, 0.05);
+    padding: 2px 6px;
+    border-radius: 4px;
+}
+
+/* Favorite Button */
+.favorite-btn {
+    background: none;
+    border: none;
+    color: #555;
+    font-size: 1.2em;
+    cursor: pointer;
+    margin-left: auto; /* Push to the far right */
+    padding: 5px;
+    transition: color 0.2s, transform 0.1s;
+}
+
+.favorite-btn:hover {
+    color: #888;
+    transform: scale(1.1);
+}
+
+.favorite-btn.favorited {
+    color: #f0c420;
+}
+
+.favorite-btn.favorited:hover {
+    color: #ffde57;
 }


### PR DESCRIPTION
This commit introduces several improvements to the Celestial Body Selector UI to enhance user experience and modernizing its look and feel.

Key changes include:
- Replaced the category filter dropdown with a tab-based interface for quicker navigation between Stars, Planets, and Moons.
- Made the search bar always visible at the top of the panel and applied a 300ms debounce to the input for smoother, instant filtering.
- Enriched each list item to display the celestial body's type (e.g., 'Planet') and a 'Favorite' button for quick bookmarking (state is session-based).
- Added a subtle hover effect (background and border highlight) to rows for better visual feedback.
- Restructured the selector's HTML and updated CSS to support the new layout and features, ensuring a clean and responsive design.