### PR TITLE
fix(ci): start dev server before running playwright tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,6 +17,8 @@ jobs:
       run: npm ci
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
+    - name: Start dev server
+      run: npm run start &
     - name: Wait for dev server
       run: npx wait-on http://localhost:3000 --timeout 60000 || (curl -v http://localhost:3000 && exit 1)
     - name: Run Playwright tests


### PR DESCRIPTION
The Playwright tests were failing in the CI environment because the application server was not running when the tests were executed.

This change adds a new step to the GitHub Actions workflow to start the dev server using `npm run start` before the `wait-on` command is called. The server is started in the background to allow the workflow to proceed with the tests.