### PR TITLE
fix(ci): Allow Playwright to reuse existing server

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -75,6 +75,6 @@ export default defineConfig({
     command: 'npm run test:e2e',
     url: 'http://localhost:3000/solarsystemsim25/',
     timeout: 300000,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: true,
   },
 });


### PR DESCRIPTION
Updates the Playwright configuration to set `reuseExistingServer: true`. This prevents test failures in CI where the dev server port is already in use by another process.

The previous setting was `!process.env.CI`, which incorrectly disabled this feature in the CI environment. This change hardcodes the value to `true` to ensure it works consistently across all environments.