### PR TITLE
Fix: Resolve CI server conflict by delegating to Playwright

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,12 +17,8 @@ jobs:
       run: npm ci
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
-    - name: Start dev server
-      run: npm run start &
-    - name: Wait for dev server
-      run: npx wait-on http://localhost:3000 --timeout 60000 || (curl -v http://localhost:3000 && exit 1)
     - name: Run Playwright tests
-      run: npx playwright test
+      run: npx playwright test --reporter=list
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -28,7 +28,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:3000/solarsystemsim25/',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -74,9 +74,10 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run start',
+    // Build + serve a production-like preview (stable, no HMR)
+    command: 'npm run build && npm run preview -- --port 3000 --strictPort --host',
     url: 'http://localhost:3000/solarsystemsim25/',
-    timeout: 120 * 1000,
-    reuseExistingServer: false,
+    reuseExistingServer: !process.env.CI, // reuse for local dev, fresh in CI
+    timeout: 120_000,                      // give build/preview time in CI
   },
 });


### PR DESCRIPTION
The CI pipeline was failing because the workflow was manually starting a dev server while Playwright was also configured to start its own, leading to a "port already in use" error.

This commit resolves the issue by adopting the recommended best practice of letting Playwright manage the server lifecycle.

Changes include:
- Updating `playwright.config.ts` to build and serve a production-like preview of the application. The `webServer` now uses `npm run build && npm run preview`.
- Setting `reuseExistingServer: !process.env.CI` to maintain a fast local development workflow while ensuring a clean server instance in CI.
- Removing the manual `npm run start` and `wait-on` steps from the `.github/workflows/playwright.yml` file.