### PR TITLE
Fix: Refactor zustand to vanilla API and fix favicon 404

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Solar System Simulator</title>
     <link rel="stylesheet" href="style.css">
+    <link rel="icon" href="./favicon.svg" type="image/svg+xml">
 </head>
 <body>
     <div id="snap-glow-top" class="snap-glow"></div>
@@ -35,27 +36,12 @@
                     <button class="control-btn time-preset" data-speed="31557600">1y/s</button>
                 </div>
             </div>
-            <!-- Moved scale control here to be always visible -->
             <div class="control-group">
                 <label for="visual-scale-slider" title="0% = Real Scale, 100% = Visual Scale">Scale:</label>
                 <input type="range" id="visual-scale-slider" min="0" max="1" value="0.5" step="0.01">
             </div>
         </div>
         <div class="top-bar-section" id="top-bar-right">
-feat/responsive-design-overhaul
-            <div class="mobile-hide">
-                <button id="visuals-toggle-btn" class="control-btn">Visuals</button>
-                <button id="settings-toggle-btn" class="control-btn">Settings</button>
-                <a id="github-link" href="https://github.com/therealsahil19/solarsystemsim25" target="_blank" rel="noopener noreferrer" title="View project on GitHub">
-                    GitHub
-                </a>
-            </div>
-            <div id="more-menu-container" class="mobile-only">
-                <button id="more-menu-toggle" class="control-btn icon-btn">
-                    <svg class="icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path></svg>
-                    <span class="sr-only">Open menu</span>
-                </button>
-=======
             <button id="visuals-toggle-btn" class="control-btn">Visuals</button>
             <button id="settings-toggle-btn" class="control-btn">Settings</button>
             <div id="scale-control-group" class="control-group">
@@ -72,7 +58,6 @@ feat/responsive-design-overhaul
             </a>
             <div id="more-menu-container">
                 <button id="more-menu-toggle" class="control-btn hidden">⋮</button>
-main
                 <div id="more-menu-content" class="panel hidden">
                     <!-- This container is populated by top-bar.ts -->
                 </div>
@@ -135,17 +120,6 @@ main
                     </div>
                 </div>
             </aside>
-
-feature/UI-UX-improvements
-        <main id="canvasArea" class="canvas-area">
-            <canvas id="bg"></canvas>
-            <div id="ui-container">
-                <div id="quick-access-toolbar" class="panel">
-                    <!-- Populated by quick-access-toolbar.ts -->
-                </div>
-                <!-- Pop-out panels for Visuals and Settings -->
-                <div id="visuals-panel" class="panel hidden" style="position: absolute; top: 70px; right: 20px; z-index: 101;">
-=======
             <!-- Main Controls Panel -->
             <div id="mainPanel" class="panel floating hidden" style="top: 20px; right: 20px;" aria-label="Main Controls Panel">
                 <header id="mainPanelHeader" class="panel-header">
@@ -162,7 +136,6 @@ feature/UI-UX-improvements
                     </div>
                 </header>
                 <div class="panel-body">
-main
                     <div class="control-group">
                         <input type="checkbox" id="trails-enabled-toggle" checked>
                         <label for="trails-enabled-toggle">Trails</label>
@@ -179,20 +152,11 @@ main
                             <option value="earthR">Earth Radii</option>
                         </select>
                     </div>
-feat/responsive-design-overhaul
-=======
-feature/new-panel-system
                     <div class="control-group">
                         <label for="visual-scale-slider" title="0% = Real Scale, 100% = Visual Scale">Scale:</label>
                         <input type="range" id="visual-scale-slider" min="0" max="1" value="0.5" step="0.01">
                     </div>
                     <hr>
-=======
-main
-                </div>
-
-                <div id="settings-panel" class="panel hidden" style="position: absolute; top: 70px; right: 20px; z-index: 101;">
-main
                     <div class="control-group tooltip">
                         <input type="checkbox" id="shadow-toggle" checked>
                         <label for="shadow-toggle" id="shadow-label">Shadows</label>
@@ -212,38 +176,6 @@ main
                     <button id="manage-presets-btn" class="control-btn">Presets</button>
                 </div>
             </div>
-
-feature/UI-UX-improvements
-                <div id="selection-panel" class="panel">
-                    <button id="open-celestial-selector-btn" class="btn">Select Body</button>
-                    <button id="free-camera-btn" class="btn hidden">Solar System View</button>
-                </div>
-
-                <div id="celestial-selector-panel" class="panel hidden" style="position: absolute; top: 120px; left: calc(50% - 175px); width: 380px; height: 550px; display: flex; flex-direction: column;">
-                    <div class="panel-header" style="cursor: grab;">
-                        <h2>Select a Celestial Body</h2>
-                        <div>
-                            <button class="control-btn minimize-btn" title="Minimize">–</button>
-                            <button id="close-celestial-selector-btn" class="control-btn" title="Close">&times;</button>
-                        </div>
-                    </div>
-                    <div id="celestial-selector" style="display: flex; flex-direction: column; flex-grow: 1; overflow: hidden; padding: 10px;">
-                        <div class="selector-controls" style="padding: 10px; background: rgba(0,0,0,0.1); border-radius: 6px; margin-bottom: 10px;">
-                            <div class="control-group" style="justify-content: space-around;">
-                                <label style="cursor: pointer; font-weight: 500;"><input type="radio" name="selector-view" value="hierarchy" checked> Hierarchy</label>
-                                <label style="cursor: pointer; font-weight: 500;"><input type="radio" name="selector-view" value="type"> By Type</label>
-                            </div>
-                        </div>
-                        <div class="search-container" style="display: flex; gap: 5px; margin-bottom: 10px;">
-                            <input type="text" id="selector-search-input" class="btn" placeholder="Search..." style="flex-grow: 1; box-sizing: border-box;">
-                        </div>
-                        <div id="category-tabs" style="display: flex; margin-bottom: 10px; border-bottom: 1px solid rgba(255, 255, 255, 0.1);">
-                            <!-- Tabs will be dynamically inserted here -->
-                        </div>
-                        <div id="celestial-selector-menu" class="dropdown-menu" style="position: relative; width: 100%; box-shadow: none; border: none; background: none; flex-grow: 1; overflow-y: auto;">
-                            <!-- Tree view will be populated by JS -->
-                        </div>
-=======
             <!-- Presets Panel -->
             <div id="presetsPanel" class="panel floating hidden" aria-label="Layout Presets Panel">
                 <header id="presetsPanelHeader" class="panel-header">
@@ -266,30 +198,9 @@ feature/UI-UX-improvements
                     <div style="margin-top: 15px; display: flex; gap: 10px;">
                         <input type="text" id="new-preset-name" class="control-btn" placeholder="New preset name..." style="flex-grow: 1;">
                         <button id="save-current-preset-btn" class="control-btn">Save Current</button>
-main
                     </div>
                 </div>
             </div>
-
-feature/UI-UX-improvements
-                <div id="contextual-hud" class="panel hidden" style="display: flex; gap: 5px; padding: 8px; transform: translate(-50%, -150%); transition: opacity 0.3s, transform 0.3s;">
-                    <button id="hud-frame-btn" class="icon-btn" title="Frame (F)">🎯</button>
-                    <button id="hud-follow-btn" class="icon-btn" title="Follow (L)">📡</button>
-                    <button id="hud-orbit-btn" class="icon-btn" title="Toggle Orbit (O)">🛰️</button>
-                    <button id="hud-info-btn" class="icon-btn" title="Show Info Panel (I)">ℹ️</button>
-                </div>
-
-                <div id="debug-hud" class="panel hidden">
-                    <h4>Debug Info</h4>
-                    <div>Preset: <span id="debug-preset"></span></div>
-                    <div>DPR: <span id="debug-dpr"></span></div>
-                    <div>Avg. ms: <span id="debug-avg-ms"></span></div>
-                    <div>Scale: <span id="debug-scale"></span></div>
-                </div>
-
-                <div id="help-overlay" class="panel hidden">
-                    <h3>Keyboard Shortcuts</h3>
-=======
             <!-- Shortcuts Panel -->
             <div id="shortcutsPanel" class="panel floating hidden" aria-label="Keyboard Shortcuts Panel">
                 <header id="shortcutsPanelHeader" class="panel-header">
@@ -306,7 +217,6 @@ feature/UI-UX-improvements
                     </div>
                 </header>
                 <div class="panel-body">
-main
                     <div class="help-search-container">
                         <input type="text" id="help-search-input" class="btn" placeholder="Search actions...">
                     </div>
@@ -315,7 +225,6 @@ main
                     </div>
                 </div>
             </div>
-
             <!-- Celestial Selector Panel -->
             <div id="celestialSelector" class="panel floating hidden" aria-label="Celestial Body Selector">
                 <header id="celestialSelectorHeader" class="panel-header">
@@ -350,7 +259,6 @@ main
                     </div>
                 </div>
             </div>
-
             <!-- Other UI elements that are not panels -->
             <div id="selection-panel" class="panel">
                 <button id="open-celestial-selector-btn" class="btn">Select Body</button>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="32" height="32">
+  <circle cx="50" cy="50" r="45" fill="black" />
+</svg>

--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -5,7 +5,7 @@ import { celestialBodyData } from './data';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { getShortcuts, ShortcutAction } from './state/shortcuts';
 import { renderShortcutsList } from './ui/shortcuts-panel';
-import { store } from './state/store';
+import store from './state/store';
 import { Simulation } from './interactions';
 
 export function setupKeyboardShortcuts(

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import { createCelestialBodySelector } from './ui/celestial-selector';
 import { setupInteractions } from './interactions';
 import { initInfoPanel, updateInfoPanelColor } from './ui/info-panel';
 import { OrbitManager } from './orbits/OrbitManager';
-import { store, ScalePreset } from './state/store';
+import store, { ScalePreset } from './state/store';
 import { setupKeyboardShortcuts } from './keyboard';
 import * as dom from './ui/dom';
 import { instantaneousOrbitalSpeed } from './orbits/kepler';

--- a/src/orbits/OrbitManager.ts
+++ b/src/orbits/OrbitManager.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { CelestialBody } from '../data';
-import { store } from '../state/store';
+import store from '../state/store';
 import { calculateDisplayPosition, ScaleTransition } from '../utils/scaling';
 import { keplerToCartesianFromMeanAnomaly, OrbitalElements as KeplerOrbitalElements } from './kepler';
 import { KM_PER_AU } from '../utils/units';

--- a/src/orbits/TrailManager.ts
+++ b/src/orbits/TrailManager.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { CelestialBody } from '../data';
-import { store } from '../state/store';
+import store from '../state/store';
 import { Trail } from './Trail';
 import { calculateDisplayPosition, ScaleTransition } from '../utils/scaling';
 import { SceneBody } from '../types/scene';

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand';
+import { createStore } from 'zustand/vanilla';
 import { subscribeWithSelector } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import { DistanceUnit } from '../utils/units';
@@ -38,7 +38,7 @@ export interface AppState {
   setPerfPreset: (preset: 'auto' | 'low' | 'medium' | 'high') => void;
 }
 
-export const useStore = create<AppState>()(
+const store = createStore<AppState>()(
   subscribeWithSelector(
     immer((set) => ({
       selectedBodyId: 'sun',
@@ -66,4 +66,22 @@ export const useStore = create<AppState>()(
   )
 );
 
-export const store = useStore;
+export default store;
+
+export const getState = store.getState;
+export const setState = store.setState;
+export const subscribe = store.subscribe;
+
+export function subscribeToSelector<T>(
+  selector: (s: AppState) => T,
+  cb: (next: T, prev: T | undefined) => void
+) {
+  let prev = selector(store.getState());
+  return store.subscribe((state) => {
+    const next = selector(state);
+    if (next !== prev) {
+      cb(next, prev);
+      prev = next;
+    }
+  });
+}

--- a/src/ui/celestial-selector.ts
+++ b/src/ui/celestial-selector.ts
@@ -2,7 +2,7 @@ import { CelestialBody } from '../data';
 import { celestialSelectorMenu } from './dom';
 import { buildTree, CelestialBodyType, TreeNode } from './tree-view';
 import Fuse from 'fuse.js';
-import { store } from '../state/store';
+import store from '../state/store';
 import { PanelManager } from './panel-manager';
 
 type ViewMode = 'hierarchy' | 'type';

--- a/src/ui/main-panel.ts
+++ b/src/ui/main-panel.ts
@@ -1,4 +1,4 @@
-import { store } from '../state/store';
+import store, { AppState } from '../state/store';
 import { DistanceUnit } from '../utils/units';
 import { sliderToTimeScale, timeScaleToSlider, TimeScaleConfig } from '../utils/timeScaleMap';
 
@@ -131,7 +131,7 @@ function initVisualsPanel() {
     });
 
     // Subscribe to store changes to keep UI in sync
-    store.subscribe((state) => {
+    store.subscribe((state: AppState) => {
         if (trailsEnabledToggle.checked !== state.trailsEnabled) {
             trailsEnabledToggle.checked = state.trailsEnabled;
         }
@@ -153,7 +153,7 @@ function initGlobalControls() {
     });
 
     // Subscribe to store changes to keep UI in sync (e.g., when a preset is loaded)
-    store.subscribe((state) => {
+    store.subscribe((state: AppState) => {
         if (distanceUnitSelect.value !== state.distanceUnit) {
             distanceUnitSelect.value = state.distanceUnit;
         }

--- a/src/ui/presets-panel.ts
+++ b/src/ui/presets-panel.ts
@@ -1,5 +1,5 @@
 import { camera, controls, renderer } from '../scene';
-import { store } from '../state/store';
+import store from '../state/store';
 import { Preset, PanelState, getAllPresets, addPreset, deletePreset } from '../state/presets';
 import { v4 as uuidv4 } from 'uuid';
 import { PanelManager } from './panel-manager';

--- a/src/ui/quick-access-toolbar.ts
+++ b/src/ui/quick-access-toolbar.ts
@@ -1,4 +1,4 @@
-import { store } from '../state/store';
+import store from '../state/store';
 import { quickAccessToolbar } from './dom';
 
 const QUICK_ACCESS_BODIES = ['Sun', 'Earth', 'Mars', 'Jupiter'];

--- a/src/ui/top-bar.ts
+++ b/src/ui/top-bar.ts
@@ -1,4 +1,4 @@
-import { store, ScalePreset } from '../state/store';
+import store, { AppState, ScalePreset } from '../state/store';
 
 // --- DOM Element References ---
 let moreMenuBtn: HTMLButtonElement;
@@ -93,7 +93,7 @@ function setupEventListeners() {
         store.getState().setScalePreset(preset);
     });
 
-    store.subscribe((state) => {
+    store.subscribe((state: AppState) => {
         const preset = state.scalePreset;
         if (scalePresetSelect.value !== preset) {
             scalePresetSelect.value = preset;


### PR DESCRIPTION
This commit addresses two main issues:
1. A production error `Could not resolve "react" imported by "zustand"`.
2. A 404 error for `favicon.ico`.

The `zustand` issue was resolved by refactoring the state management to use `zustand/vanilla`. This involved:
- Updating `src/state/store.ts` to use `createStore` and export a vanilla-compatible store API.
- Updating all files that use the store to import the store correctly and use the vanilla API (`getState`, `subscribe`).

The `favicon.ico` 404 error was resolved by:
- Adding a placeholder `favicon.svg` to the `public/` directory.
- Updating `index.html` to link to the new favicon.

Additionally, this commit includes a cleanup of `index.html`, which was corrupted with merge conflict markers.