### PR TITLE
Fix: Resolve GitHub Pages deployment issues

### DIFF
--- a/src/bodies/rings.ts
+++ b/src/bodies/rings.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { CelestialBody } from '../data';
+import { getAssetUrl } from '../utils/assets';
 import { scaleRingRadius } from '../utils/misc';
 
 function createJupiterRings(p_data: CelestialBody, planetGroup: THREE.Group) {
@@ -112,7 +113,7 @@ function createSaturnRings(p_data: CelestialBody, planetGroup: THREE.Group, text
     };
 
     textureLoader.load(
-        ringData.texture!,
+        getAssetUrl(ringData.texture!),
         (ringTexture) => {
             ringTexture.colorSpace = THREE.SRGBColorSpace;
             const ringMaterial = new THREE.MeshStandardMaterial({

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import { initContextualHud } from './ui/contextual-hud';
 import { initOnboardingTour } from './ui/onboarding-tour';
 import { TrailManager } from './orbits/TrailManager';
 import { initTooltips } from './ui/dom';
+import { getAssetUrl } from './utils/assets';
 
 async function start() {
     if (import.meta.env.MODE === 'test') {
@@ -127,14 +128,14 @@ async function start() {
                 color: 0xffff00
             });
             if (bodyData.texture) {
-                const sunTexture = textureLoader.load(bodyData.texture);
+                const sunTexture = textureLoader.load(getAssetUrl(bodyData.texture));
                 bodyMaterial.map = sunTexture;
                 bodyMaterial.emissiveMap = sunTexture;
             }
         } else {
             bodyMaterial = new THREE.MeshStandardMaterial({ color: bodyData.color || 0xffffff });
             if (bodyData.texture) {
-                bodyMaterial.map = textureLoader.load(bodyData.texture);
+                bodyMaterial.map = textureLoader.load(getAssetUrl(bodyData.texture));
             }
         }
 
@@ -765,4 +766,4 @@ async function start() {
     }
 }
 
-start();
+window.addEventListener('DOMContentLoaded', start);

--- a/src/utils/assets.ts
+++ b/src/utils/assets.ts
@@ -1,0 +1,13 @@
+/**
+ * Prepends the Vite base URL to a given asset path.
+ * This ensures that assets are loaded correctly from the /public directory
+ * both in development and in a production deployment with a subpath.
+ * @param path The relative path to the asset from the /public directory.
+ * @returns A full, correct path to the asset.
+ */
+export function getAssetUrl(path: string): string {
+  // import.meta.env.BASE_URL is a Vite feature that provides the base public path.
+  // It includes a trailing slash, and our asset paths in data.ts do not have a leading slash,
+  // so we can concatenate them directly.
+  return `${import.meta.env.BASE_URL}${path}`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,9 @@ import checker from 'vite-plugin-checker';
 
 export default defineConfig({
   base: '/solarsystemsim25/',
+  build: {
+    sourcemap: false,
+  },
   server: {
     host: true,
     port: 3000,


### PR DESCRIPTION
This commit addresses several issues that prevented the application from running correctly when deployed to GitHub Pages.

The key changes include:

1.  **Vite Configuration**: Disabled sourcemaps for production builds in `vite.config.ts` to reduce build noise and size.
2.  **Asset Path Resolution**: Introduced a `getAssetUrl` utility function that correctly prepends the Vite base URL to asset paths. This ensures that textures located in the `/public` directory are loaded correctly on a subdirectory path. Updated all `textureLoader.load()` calls to use this new utility.
3.  **DOM Initialization**: Wrapped the main application's `start()` call in a `DOMContentLoaded` event listener to prevent race conditions and ensure the script executes only after the DOM is fully loaded.

These changes align with the recommended fixes for deploying Vite applications to GitHub Pages and should resolve the 404 errors and module loading failures.