### PR TITLE
Fix Three.js runtime errors and userData warnings

### DIFF
--- a/src/bodies/rings.ts
+++ b/src/bodies/rings.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { CelestialBody } from '../data';
 import { getAssetUrl } from '../utils/assets';
 import { scaleRingRadius } from '../utils/misc';
+import { initUserDataIfMissing } from '../utils/three-helpers';
 
 function createJupiterRings(p_data: CelestialBody, planetGroup: THREE.Group) {
     const ringData = p_data.rings!;
@@ -55,6 +56,7 @@ function createJupiterRings(p_data: CelestialBody, planetGroup: THREE.Group) {
             0.02,
             0.05
         );
+        initUserDataIfMissing(mainRing, { name: `${p_data.name} Main Ring` });
         ringGroup.add(mainRing);
     }
 
@@ -67,6 +69,7 @@ function createJupiterRings(p_data: CelestialBody, planetGroup: THREE.Group) {
             0.02,
             0.02
         );
+        initUserDataIfMissing(haloRing, { name: `${p_data.name} Halo Ring` });
         ringGroup.add(haloRing);
     }
 
@@ -79,6 +82,7 @@ function createJupiterRings(p_data: CelestialBody, planetGroup: THREE.Group) {
             0.015,
             0.01
         );
+        initUserDataIfMissing(gossamerRing, { name: `${p_data.name} Gossamer Ring` });
         ringGroup.add(gossamerRing);
     });
 }
@@ -109,6 +113,7 @@ function createSaturnRings(p_data: CelestialBody, planetGroup: THREE.Group, text
             metalness: 0.1,
         });
         const rings = new THREE.Mesh(ringGeometry, fallbackMaterial);
+        initUserDataIfMissing(rings, { name: `${p_data.name} Rings (Fallback)` });
         ringGroup.add(rings);
     };
 
@@ -126,6 +131,7 @@ function createSaturnRings(p_data: CelestialBody, planetGroup: THREE.Group, text
                 metalness: 0.1,
             });
             const rings = new THREE.Mesh(ringGeometry, ringMaterial);
+            initUserDataIfMissing(rings, { name: `${p_data.name} Rings` });
             ringGroup.add(rings);
         },
         undefined,
@@ -178,6 +184,7 @@ function createUranusRings(p_data: CelestialBody, planetGroup: THREE.Group) {
         const outerRadius = scaleRingRadius(band.outerRadius);
         const ringGeometry = new THREE.RingGeometry(innerRadius, outerRadius, 128);
         const ring = new THREE.Mesh(ringGeometry, ringMaterial);
+        initUserDataIfMissing(ring, { name: `${p_data.name} Ring (${band.type})` });
         ringGroup.add(ring);
     });
 }
@@ -225,6 +232,7 @@ function createNeptuneRings(p_data: CelestialBody, planetGroup: THREE.Group) {
         const outerRadius = scaleRingRadius(band.outerRadius);
         const ringGeometry = new THREE.RingGeometry(innerRadius, outerRadius, 256);
         const ring = new THREE.Mesh(ringGeometry, ringMaterial);
+        initUserDataIfMissing(ring, { name: `${p_data.name} Ring (${band.type})` });
         ringGroup.add(ring);
     });
 
@@ -237,7 +245,7 @@ function createNeptuneRings(p_data: CelestialBody, planetGroup: THREE.Group) {
         metalness: 0.2,
     });
 
-    ringData.arcs!.forEach(arc => {
+    ringData.arcs!.forEach((arc, index) => {
         const innerRadius = scaleRingRadius(arc.innerRadius);
         const outerRadius = scaleRingRadius(arc.outerRadius);
         const arcGeometry = new THREE.RingGeometry(
@@ -249,6 +257,7 @@ function createNeptuneRings(p_data: CelestialBody, planetGroup: THREE.Group) {
             arc.thetaLength
         );
         const arcMesh = new THREE.Mesh(arcGeometry, arcMaterial);
+        initUserDataIfMissing(arcMesh, { name: `${p_data.name} Ring Arc ${index + 1}` });
         ringGroup.add(arcMesh);
     });
 }

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -3,6 +3,7 @@ import * as TWEEN from '@tweenjs/tween.js';
 import * as dom from './ui/dom';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { showHud } from './ui/contextual-hud';
+import { warnOnce } from './utils/three-helpers';
 
 // The simulation object is now simpler, as most state is in the store.
 export type Simulation = {
@@ -41,9 +42,7 @@ export function setupInteractions(
 
             if (intersects.length > 0) {
                 const hovered = intersects[0].object;
-                // Add defensive check for userData.data
-                const userData = hovered.userData;
-                const data = userData?.data;
+                const data = hovered.userData?.data;
                 const name = data?.name;
                 const radius = data?.radius;
 
@@ -53,7 +52,7 @@ export function setupInteractions(
                     tooltipElement.style.top = `${event.clientY + 15}px`;
                     tooltipElement.classList.remove('hidden');
                 } else {
-                    console.warn('Object missing valid userData.data:', hovered);
+                    warnOnce(hovered.uuid, 'Object missing valid userData.data:', hovered);
                     tooltipElement.classList.add('hidden');
                 }
             } else {
@@ -84,8 +83,11 @@ export function setupInteractions(
 
         if (intersects.length > 0) {
             const clicked = intersects[0].object;
-            onBodySelected(clicked.userData.name);
-            showHud(clicked, camera);
+            const bodyName = clicked.userData?.data?.name;
+            if (bodyName) {
+                onBodySelected(bodyName);
+                showHud(clicked, camera);
+            }
         } else {
             const groundPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
             const intersection = new THREE.Vector3();
@@ -130,8 +132,9 @@ export function setupInteractions(
     }
 
     dom.btnFrame.addEventListener('click', () => {
-        if (simulation.selectedObject) {
-            onBodySelected(simulation.selectedObject.userData.name);
+        const bodyName = simulation.selectedObject?.userData?.data?.name;
+        if (bodyName) {
+            onBodySelected(bodyName);
             triggerButtonFlash(dom.btnFrame);
         }
     });
@@ -152,8 +155,9 @@ export function setupInteractions(
     });
 
     dom.btnOrbit.addEventListener('click', () => {
-        if (!simulation.selectedObject) return;
-        const bodyName = simulation.selectedObject.userData.name;
+        const bodyName = simulation.selectedObject?.userData?.data?.name;
+        if (!bodyName) return;
+
         const orbit = orbits.find(o => o.userData.name === bodyName);
         if (orbit) {
             orbit.visible = !orbit.visible;

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import { initOnboardingTour } from './ui/onboarding-tour';
 import { TrailManager } from './orbits/TrailManager';
 import { initTooltips } from './ui/dom';
 import { getAssetUrl } from './utils/assets';
+import { initUserDataIfMissing } from './utils/three-helpers';
 
 async function start() {
     if (import.meta.env.MODE === 'test') {
@@ -297,6 +298,7 @@ async function start() {
             );
         };
         const inst = new THREE.InstancedMesh(geom, material, count);
+        initUserDataIfMissing(inst, { name: 'Asteroid Belt' });
         inst.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
         const distanceScale = 150.0; // 1 AU = 150 meters in the simulation
         const beltMin = 2.2 * distanceScale;
@@ -328,6 +330,7 @@ async function start() {
         const geom = new THREE.SphereGeometry(0.5, 6, 6);
         const mat = new THREE.MeshStandardMaterial({ color: 0x446688, transparent: true, opacity: 0.5 });
         const inst = new THREE.InstancedMesh(geom, mat, count);
+        initUserDataIfMissing(inst, { name: 'Oort Cloud' });
         const dummy = new THREE.Object3D();
         for (let i = 0; i < count; i++) {
             const u = Math.random();

--- a/src/orbits/Trail.ts
+++ b/src/orbits/Trail.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { Line2 } from 'three/examples/jsm/lines/Line2.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
+import { safeSetPositions } from '../utils/three-helpers';
 
 export class Trail {
     line: Line2;
@@ -29,50 +30,15 @@ export class Trail {
     }
 
     updateFromSampledPoints(sampledPositions: THREE.Vector3[]) {
-        // Defensive checks to prevent RangeError
-        if (!sampledPositions || !Array.isArray(sampledPositions)) {
-            console.warn('updateFromSampledPoints: Invalid sampledPositions - not an array or undefined');
-            this.geometry.setPositions([]);
-            return;
-        }
-
-        if (sampledPositions.length < 0) {
-            console.warn('updateFromSampledPoints: sampledPositions.length is negative:', sampledPositions.length);
-            this.geometry.setPositions([]);
+        if (!sampledPositions || sampledPositions.length < 2) {
+            safeSetPositions(this.geometry, []);
             return;
         }
 
         const numPoints = Math.min(this.maxPoints, sampledPositions.length);
 
-        if (numPoints < 2) {
-            this.geometry.setPositions([]);
-            return;
-        }
-
-        // Additional safety check for numPoints
-        if (numPoints <= 0 || !isFinite(numPoints)) {
-            console.warn('updateFromSampledPoints: Invalid numPoints:', numPoints);
-            this.geometry.setPositions([]);
-            return;
-        }
-
-        // Ensure we don't create an array that's too large or negative
-        if (numPoints < 0) {
-            // This is a critical guard. Although other checks should prevent this,
-            // this explicitly stops a negative length from being calculated.
-            console.error(`updateFromSampledPoints: numPoints is negative (${numPoints}), which would cause a crash. Aborting trail update.`);
-            this.geometry.setPositions([]);
-            return;
-        }
-        const positionsArrayLength = numPoints * 3;
-        if (positionsArrayLength < 0 || positionsArrayLength > 1000000) { // Reasonable upper limit
-            console.warn('updateFromSampledPoints: Invalid positionsArrayLength:', positionsArrayLength);
-            this.geometry.setPositions([]);
-            return;
-        }
-
-        const positions = new Float32Array(positionsArrayLength);
-        const colors = new Float32Array(positionsArrayLength);
+        const positions = new Float32Array(numPoints * 3);
+        const colors = new Float32Array(numPoints * 3);
 
         // The tail of the trail is at the beginning of the array (oldest points).
         // We fade the first 5% of the trail to black to simulate fading out.
@@ -88,12 +54,11 @@ export class Trail {
                 positions[i * 3] = 0;
                 positions[i * 3 + 1] = 0;
                 positions[i * 3 + 2] = 0;
-                continue;
+            } else {
+                positions[i * 3] = p.x;
+                positions[i * 3 + 1] = p.y;
+                positions[i * 3 + 2] = p.z;
             }
-
-            positions[i * 3] = p.x;
-            positions[i * 3 + 1] = p.y;
-            positions[i * 3 + 2] = p.z;
 
             let fade = 1.0;
             if (i < fadeEndIndex) {
@@ -106,8 +71,8 @@ export class Trail {
             colors[i * 3 + 2] = this.baseColor.b * fade;
         }
 
-        this.geometry.setPositions(positions);
         this.geometry.setColors(colors);
+        safeSetPositions(this.geometry, positions, { nameForWarnings: 'trail-line' });
     }
 
     updateResolution(x: number, y: number) {

--- a/src/utils/three-helpers.ts
+++ b/src/utils/three-helpers.ts
@@ -1,0 +1,73 @@
+// src/utils/three-helpers.ts
+// Minimal, defensive helpers for Three.js arrays and userData handling.
+
+type AnyGeometryWithSetPositions = { setPositions?: (p: any) => void; visible?: boolean; };
+
+// Warn once per key (uuid or custom string)
+const _warned = new Set<string>();
+export function warnOnce(key: string, ...args: any[]) {
+  if (_warned.has(key)) return;
+  _warned.add(key);
+  // eslint-disable-next-line no-console
+  console.warn(...args);
+}
+
+/**
+ * Safe wrapper for LineGeometry / LineSegmentsGeometry setPositions.
+ * - positions may be Array<number> or Float32Array.
+ * - If isSegments = true, we require length % 6 === 0 (pairs).
+ * - Otherwise require length % 3 === 0 (xyz triplets).
+ */
+export function safeSetPositions(
+  geometry: AnyGeometryWithSetPositions,
+  positions: ArrayLike<number> | null | undefined,
+  opts?: { isSegments?: boolean; nameForWarnings?: string }
+) {
+  if (!geometry || typeof geometry.setPositions !== 'function') {
+    return;
+  }
+  const isSegments = !!opts?.isSegments;
+  const nameForWarnings = opts?.nameForWarnings ?? 'geometry';
+
+  if (!positions) {
+    geometry.visible = false;
+    return;
+  }
+
+  const len = (positions as any).length ?? 0;
+  if (len === 0) {
+    geometry.visible = false;
+    return;
+  }
+
+  if (len % 3 !== 0) {
+    warnOnce(`invalid_len_${nameForWarnings}`, `[safeSetPositions] skipping invalid positions length=${len} for ${nameForWarnings} (expected multiple of 3).`);
+    geometry.visible = false;
+    return;
+  }
+
+  if (isSegments && (len % 6 !== 0)) {
+    warnOnce(`invalid_segments_len_${nameForWarnings}`, `[safeSetPositions] skipping invalid segments length=${len} for ${nameForWarnings} (expected multiple of 6).`);
+    geometry.visible = false;
+    return;
+  }
+
+  try {
+    geometry.setPositions(positions);
+    geometry.visible = true;
+  } catch (err) {
+    warnOnce(`setPositions_throw_${nameForWarnings}`, `[safeSetPositions] setPositions failed for ${nameForWarnings}:`, err);
+    geometry.visible = false;
+  }
+}
+
+/**
+ * Ensure object has userData.data (optionally fill with defaultData)
+ */
+export function initUserDataIfMissing(obj: any, defaultData: any = {}) {
+  if (!obj) return;
+  obj.userData = obj.userData || {};
+  if (!obj.userData.data) {
+    obj.userData.data = defaultData;
+  }
+}


### PR DESCRIPTION
This commit addresses two critical runtime issues: a `RangeError` crash in the Three.js line geometry and repeated console warnings for missing `userData.data`.

The key changes include:

1.  **`safeSetPositions` Wrapper:** A new `safeSetPositions` function has been added to `src/utils/three-helpers.ts`. This function wraps the `setPositions` call for `LineGeometry` and `LineSegmentsGeometry`, providing defensive checks to prevent crashes when an empty or invalid array is passed. All calls in `src/orbits/Trail.ts` have been updated to use this safe wrapper.

2.  **`userData.data` Guarding:** A `warnOnce` helper was added to prevent console spam. All code that accesses `object.userData.data` (primarily in `src/interactions.ts`) has been guarded to check for the existence of the data before access, using optional chaining and the `warnOnce` helper for logging.

3.  **`userData` Initialization:** To proactively prevent missing data, the `initUserDataIfMissing` helper was added. This function is now called at all mesh and points creation sites (`src/main.ts` for asteroids/Oort cloud and `src/bodies/rings.ts` for all planetary rings) to ensure every object in the scene has a default `userData.data` structure.

These changes make the application more robust, prevent runtime crashes, and eliminate console spam, as requested by the user.