### PR TITLE
Fix: Resolve all ESLint errors

### DIFF
--- a/src/app/simulation.ts
+++ b/src/app/simulation.ts
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import * as TWEEN from '@tweenjs/tween.js';
 import { LOD } from 'three';
-import { gsap } from 'gsap';
 import { camera, controls, renderer, scene } from '../scene';
 import { CelestialBody, celestialBodyData } from '../data';
 import { AU_TO_M, speedDisplayKmPerS } from '../utils/misc';

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,6 @@ import { initOnboardingTour } from './components/onboarding-tour';
 import { LayoutManager } from './components/layout-manager';
 import { createCelestialBodySelector } from './components/celestial-selector';
 import { celestialBodyData } from './data';
-import { InfoPanelManager } from './components/info-panel-manager';
 import { setupKeyboardShortcuts } from './keyboard';
 import { setupInteractions } from './interactions';
 import store from './state/store';
@@ -29,8 +28,6 @@ async function start() {
 
     const { celestialObjects, selectableObjects, bodyMap, sun, asteroidUniforms } = await createScene();
     const simulation = new Simulation(celestialObjects, bodyMap, sun, asteroidUniforms);
-
-    const infoPanelManager = new InfoPanelManager();
 
     function onBodySelected(id: string) {
         simulation.onBodySelected(id, selectableObjects);

--- a/src/utils/misc.test.ts
+++ b/src/utils/misc.test.ts
@@ -52,9 +52,9 @@ describe('misc utilities', () => {
     });
 
     it('should handle invalid inputs', () => {
-      // @ts-ignore
+      // @ts-expect-error: Testing invalid input
       expect(speedDisplayKmPerS(null)).toBe('N/A');
-      // @ts-ignore
+      // @ts-expect-error: Testing invalid input
       expect(speedDisplayKmPerS(undefined)).toBe('N/A');
       expect(speedDisplayKmPerS(NaN)).toBe('N/A');
     });

--- a/src/utils/scaling.test.ts
+++ b/src/utils/scaling.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import * as THREE from 'three';
 import { calculateDisplayPosition, getDisplayRadius, ScaleTransition } from './scaling';
-import { ScalePreset } from '../state/store';
 
 describe('scaling utilities', () => {
   describe('calculateDisplayPosition', () => {
@@ -61,7 +60,7 @@ describe('scaling utilities', () => {
         fromPreset: 'realistic',
         toPreset: 'realistic',
       };
-      // @ts-ignore
+      // @ts-expect-error: Testing invalid input
       const displayPosition = calculateDisplayPosition(null, transition);
       expect(displayPosition).toEqual(new THREE.Vector3(0, 0, 0));
     });


### PR DESCRIPTION
This commit addresses all six ESLint errors reported by `npm run lint`.

The following changes were made:
- Removed unused `gsap` import in `src/app/simulation.ts`.
- Removed unused `infoPanelManager` variable in `src/main.ts`.
- Removed unused `ScalePreset` import in `src/utils/scaling.test.ts`.
- Replaced `@ts-ignore` with `@ts-expect-error` and added descriptive comments in `src/utils/misc.test.ts` and `src/utils/scaling.test.ts` to resolve linting errors.