### PR TITLE
fix(types): Allow null for CelestialBody texture property

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -112,7 +112,7 @@ export interface CelestialBody {
   /** The eccentricity of the orbit (0 is a perfect circle). */
   eccentricity: number;
   /** An optional path to a texture file for the body's surface. */
-  texture?: string;
+  texture?: string | null;
   /** An optional `Rings` object describing the body's ring system. */
   rings?: Rings;
   /** The axial tilt of the body in degrees. */


### PR DESCRIPTION
Updates the `CelestialBody` interface to change the `texture` property type from `string` to `string | null`.

This resolves a TypeScript `TS2322` error caused by `strictNullChecks` where celestial bodies without a texture were assigned `null`, which is not assignable to `string`.