### PR TITLE
fix: Remove camera panning on empty space click

### DIFF
--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -132,16 +132,6 @@ export function setupInteractions(
                 onBodySelected(bodyId);
                 showHud(clicked, camera);
             }
-        } else {
-            // Clicked on empty space, pan the camera target
-            const groundPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
-            const intersection = new THREE.Vector3();
-            raycaster.ray.intersectPlane(groundPlane, intersection);
-
-            new TWEEN.Tween(controls.target)
-                .to({ x: intersection.x, y: intersection.y, z: intersection.z }, 500)
-                .easing(TWEEN.Easing.Cubic.Out)
-                .start();
         }
     });
 


### PR DESCRIPTION
This commit removes the feature that caused the camera to pan when the user left-clicked on empty space. The logic for this was located in the `else` block of the `click` event listener in `src/interactions.ts`.

This change addresses the user's request to remove the unwanted camera movement.